### PR TITLE
new License file, and pointer from readme

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020-present, Aatish Bhatia and Henry Reich.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Created by [Aatish Bhatia](https://aatishb.com/) in collaboration with [Henry Re
 **With thanks to Upasana Roy, Connie Sun, Ritwick Ghosh, Ann Bybee-Finley, Nicky Case, Mustafa Paksoy, Shekhar Bhatia, Arkarup Banerjee, and Igor Kholopov for their very helpful feedback & suggestions!** Any mistakes or omissions are mine.
 
 Created using [Plotly.js](https://plot.ly/javascript/) and [Vue.js](https://vuejs.org/)
+
+## License 
+Code in this repository which is not otherwise licensed is licensed under the MIT License; see [LICENSE.md](LICENSE.md) for complete text.


### PR DESCRIPTION
Added an explicit license for the code, using the standard naming convention in github.  I'm proposing the MIT license as that's a very common permissive license, and the license used by plotly and vue.  I don't think there's any data actually in the repository, since it's all pulled dynamically from external sources, so there is no need to address that.